### PR TITLE
refactor: improve api key lookup by using key prefix

### DIFF
--- a/services/web/src/db/schema.ts
+++ b/services/web/src/db/schema.ts
@@ -75,6 +75,7 @@ export const apiKeys = pgTable(
       .references(() => projects.id, { onDelete: 'cascade' })
       .notNull(),
     name: text('name').notNull(),
+    keyPrefix: text('key_prefix').notNull(),
     secretKeyHash: text('secret_key_hash').notNull(),
     allowedEnvironmentIds: jsonb('allowed_environment_ids').notNull().default('[]'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
@@ -82,7 +83,7 @@ export const apiKeys = pgTable(
   },
   (table) => [
     index('api_keys_project_id_idx').on(table.projectId),
-    index('api_keys_secret_key_hash_idx').on(table.secretKeyHash),
+    index('api_keys_key_prefix_idx').on(table.keyPrefix),
   ]
 );
 

--- a/services/web/src/lib/repositories/api-key-repository.ts
+++ b/services/web/src/lib/repositories/api-key-repository.ts
@@ -5,6 +5,7 @@ export type ApiKey = {
   id: string;
   projectId: string;
   name: string;
+  keyPrefix: string;
   secretKeyHash: string;
   allowedEnvironmentIds: string[];
   createdAt: Date;
@@ -34,9 +35,18 @@ export class ApiKeyRepository {
     return results.map(this.toDomain);
   }
 
+  async findByKeyPrefix(keyPrefix: string): Promise<ApiKey | null> {
+    const result = await db.query.apiKeys.findFirst({
+      where: eq(apiKeys.keyPrefix, keyPrefix),
+    });
+
+    return result ? this.toDomain(result) : null;
+  }
+
   async create(data: {
     projectId: string;
     name: string;
+    keyPrefix: string;
     secretKeyHash: string;
     allowedEnvironmentIds: string[];
   }): Promise<ApiKey> {
@@ -45,6 +55,7 @@ export class ApiKeyRepository {
       .values({
         projectId: data.projectId,
         name: data.name,
+        keyPrefix: data.keyPrefix,
         secretKeyHash: data.secretKeyHash,
         allowedEnvironmentIds: data.allowedEnvironmentIds,
       })
@@ -57,6 +68,7 @@ export class ApiKeyRepository {
     id: string,
     data: {
       name?: string;
+      keyPrefix?: string;
       secretKeyHash?: string;
       allowedEnvironmentIds?: string[];
     }
@@ -79,6 +91,7 @@ export class ApiKeyRepository {
       id: row.id,
       projectId: row.projectId,
       name: row.name,
+      keyPrefix: row.keyPrefix,
       secretKeyHash: row.secretKeyHash,
       allowedEnvironmentIds: row.allowedEnvironmentIds as string[],
       createdAt: row.createdAt,


### PR DESCRIPTION
This is O(n):

```typescript
const allKeys = await this.apiKeyRepo.findAll();

for (const apiKey of allKeys) {
  if (this.verifySecretKey(secretKey, apiKey.secretKeyHash)) {
    this.apiKeyRepo.updateLastUsedAt(apiKey.id).catch(() => {});
    return {
      projectId: apiKey.projectId,
      allowedEnvironmentIds: apiKey.allowedEnvironmentIds,
    };
  }
```

This is O(1):

```typescript
const apiKey = await this.apiKeyRepo.findByKeyPrefix(keyPrefix);
await this.apiKeyRepo.updateLastUsedAt(apiKey.id);
```