### PR TITLE
build(core): prepare on local install automatically

### DIFF
--- a/domains/core/package.json
+++ b/domains/core/package.json
@@ -13,6 +13,7 @@
     }
   },
   "scripts": {
+    "prepare": "tsup src/index.ts --format cjs,esm --dts --clean",
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
     "test": "vitest run"
   },


### PR DESCRIPTION
@nishantawasthi this solves the issue you had when the dist wasn't available after `pnpm i` on first local setup.